### PR TITLE
feat: Add Postgres configuration

### DIFF
--- a/config/database.js
+++ b/config/database.js
@@ -1,11 +1,28 @@
 module.exports = ({ env }) => ({
-  defaultConnection: 'default',
+  defaultConnection: env('CONNECTION', 'default'),
   connections: {
     default: {
       connector: 'bookshelf',
       settings: {
         client: 'sqlite',
         filename: env('DATABASE_FILENAME', '.tmp/data.db')
+      },
+      options: {
+        useNullAsDefault: true
+      }
+    },
+    production: {
+      connector: 'bookshelf',
+      settings: {
+        client: 'postgres',
+        host: env('POSTGRES_HOST'),
+        port: env.int('POSTGRES_PORT', 5432),
+        database: env('POSTGRES_NAME'),
+        username: env('POSTGRES_USERNAME'),
+        password: env('POSTGRES_PASSWORD'),
+        ssl: {
+          rejectUnauthorized: env.bool('POSTGRES_SSL_SELF', false) // For self-signed certificates
+        }
       },
       options: {
         useNullAsDefault: true


### PR DESCRIPTION
Example secret for environment variables:

```yaml
apiVersion: v1
kind: Secret
metadata:
  name: cms-env-vars
type: kubernetes.io/basic-auth
stringData:
  CONNECTION: production
  ADMIN_JWT_SECRET: some-random-hash
  POSTGRES_HOST: localhost // (sidecar domain?)
  POSTGRES_NAME: a-database-name
  POSTGRES_USERNAME: a-username
  POSTGRES_PASSWORD: a-password
```

closes #4 