### PR TITLE
feat: add Google IAP support

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -12,6 +12,9 @@
     "plugin:import/warnings"
   ],
   "plugins": ["html", "json", "prettier", "eslint-comments"],
+  "globals": {
+    "strapi": "writable"
+  },
   "rules": {
     "prettier/prettier": [
       "error",
@@ -35,7 +38,6 @@
         ]
       }
     ],
-    "global": "strapi",
     "no-use-before-define": "off",
     "no-restricted-globals": "off",
     "no-underscore-dangle": "off",

--- a/api/fancy-article/controllers/fancy-article.js
+++ b/api/fancy-article/controllers/fancy-article.js
@@ -1,5 +1,3 @@
-'use strict';
-
 /**
  * Read the documentation (https://strapi.io/documentation/developer-docs/latest/development/backend-customization.html#core-controllers)
  * to customize this controller

--- a/api/fancy-article/models/fancy-article.js
+++ b/api/fancy-article/models/fancy-article.js
@@ -1,5 +1,3 @@
-'use strict';
-
 /**
  * Read the documentation (https://strapi.io/documentation/developer-docs/latest/development/backend-customization.html#lifecycle-hooks)
  * to customize this model

--- a/api/fancy-article/services/fancy-article.js
+++ b/api/fancy-article/services/fancy-article.js
@@ -1,5 +1,3 @@
-'use strict';
-
 /**
  * Read the documentation (https://strapi.io/documentation/developer-docs/latest/development/backend-customization.html#core-services)
  * to customize this service

--- a/config/database.js
+++ b/config/database.js
@@ -1,3 +1,4 @@
+/* eslint no-console: off */
 module.exports = ({ env }) => {
   const connection = env('CONNECTION', 'default');
   console.log(`Current Connection: ${connection}`);

--- a/extensions/users-permissions/config/policies/permissions.js
+++ b/extensions/users-permissions/config/policies/permissions.js
@@ -1,6 +1,3 @@
-'use strict';
-
-const _ = require('lodash');
 const { OAuth2Client } = require('google-auth-library');
 const oAuth2Client = new OAuth2Client();
 

--- a/extensions/users-permissions/config/policies/permissions.js
+++ b/extensions/users-permissions/config/policies/permissions.js
@@ -37,7 +37,7 @@ module.exports = async (ctx, next) => {
     );
     const payload = ticket.getPayload();
     if (!ticket || !payload) {
-      return handleErrors(ctx, undefined, 'forbidden');
+      throw handleErrors(ctx, undefined, 'forbidden');
     }
 
     const { email } = payload;
@@ -92,13 +92,11 @@ module.exports = async (ctx, next) => {
     );
 
   if (!permission) {
-    return handleErrors(ctx, undefined, 'forbidden');
+    throw handleErrors(ctx, undefined, 'forbidden');
   }
 
   // Execute the action.
-  await next();
+  return next();
 };
 
-const handleErrors = (ctx, err = undefined, type) => {
-  throw strapi.errors[type](err);
-};
+const handleErrors = (ctx, err = undefined, type) => strapi.errors[type](err);

--- a/extensions/users-permissions/config/policies/permissions.js
+++ b/extensions/users-permissions/config/policies/permissions.js
@@ -1,0 +1,100 @@
+'use strict';
+
+const _ = require('lodash');
+const { OAuth2Client } = require('google-auth-library');
+const oAuth2Client = new OAuth2Client();
+
+module.exports = async (ctx, next) => {
+  let role = await strapi
+    .query('role', 'users-permissions')
+    .findOne({ type: 'public' }, []);
+
+  if (process.env.NODE_ENV === 'development' && ctx.state.user) {
+    // request is already authenticated in a different way
+    return next();
+  }
+
+  if (
+    ctx.request &&
+    ctx.request.header &&
+    ctx.request.header['x-goog-iap-jwt-assertion']
+  ) {
+    if (ctx.state.user) {
+      // request is already authenticated in a different way
+      return next();
+    }
+    const iapJwt = ctx.request.header['x-goog-iap-jwt-assertion'];
+    const response = await oAuth2Client.getIapPublicKeys();
+    const ticket = await oAuth2Client.verifySignedJwtWithCertsAsync(
+      iapJwt,
+      response.pubkeys,
+      expectedAudience,
+      ['https://cloud.google.com/iap']
+    );
+    const payload = ticket.getPayload();
+    if (!ticket || !payload) {
+      return handleErrors(ctx, undefined, 'forbidden');
+    }
+
+    const email = payload.email;
+
+    ctx.state.user = await strapi.plugins[
+      'users-permissions'
+    ].services.user.fetch({ email }, ['role']);
+
+    if (!ctx.state.user) {
+      try {
+        const advanced = await strapi
+          .store({
+            environment: '',
+            type: 'plugin',
+            name: 'users-permissions',
+            key: 'advanced'
+          })
+          .get();
+
+        const defaultRole = await strapi
+          .query('role', 'users-permissions')
+          .findOne({ type: advanced.default_role }, []);
+
+        ctx.state.user = await strapi.plugins[
+          'users-permissions'
+        ].services.user.add({
+          username: email,
+          email,
+          role: defaultRole,
+          confirmed: true
+        });
+      } catch (err) {
+        console.log('Exception in user creation in permissions', err);
+      }
+    }
+
+    role = ctx.state.user.role;
+  }
+
+  const route = ctx.request.route;
+  const permission = await strapi
+    .query('permission', 'users-permissions')
+    .findOne(
+      {
+        role: role.id,
+        type: route.plugin || 'application',
+        controller: route.controller,
+        action: route.action,
+        enabled: true
+      },
+      []
+    );
+
+  if (!permission) {
+    return handleErrors(ctx, undefined, 'forbidden');
+  }
+
+  // Execute the action.
+  await next();
+};
+
+const handleErrors = (ctx, err = undefined, type) => {
+  throw strapi.errors[type](err);
+};

--- a/extensions/users-permissions/config/policies/permissions.js
+++ b/extensions/users-permissions/config/policies/permissions.js
@@ -3,9 +3,9 @@ const { OAuth2Client } = require('google-auth-library');
 const oAuth2Client = new OAuth2Client();
 
 // TODO: Add stuff below
-// TODO: Make variables configurable
-const backendServiceId = ''; // run `gcloud compute backend-services describe SERVICE_NAME --project=PROJECT_ID --global` (id)
-const projectNumber = ''; // run `gcloud projects describe PROJECT_ID` (projectNumber (INT))
+// TODO: Make env variables configurable in config files.
+const backendServiceId = process.env.BACKEND_SERVICE_ID; // run `gcloud compute backend-services describe SERVICE_NAME --project=PROJECT_ID --global` (id)
+const projectNumber = process.env.PROJECT_NUMBER; // run `gcloud projects describe PROJECT_ID` (projectNumber (INT))
 const expectedAudience = `/projects/${projectNumber}/global/backendServices/${backendServiceId}`;
 
 module.exports = async (ctx, next) => {
@@ -70,7 +70,7 @@ module.exports = async (ctx, next) => {
           confirmed: true
         });
       } catch (err) {
-        console.log('Exception in user creation in permissions', err);
+        throw new Error('Exception in user creation in permissions');
       }
     }
 

--- a/extensions/users-permissions/config/policies/permissions.js
+++ b/extensions/users-permissions/config/policies/permissions.js
@@ -1,5 +1,12 @@
 const { OAuth2Client } = require('google-auth-library');
+
 const oAuth2Client = new OAuth2Client();
+
+// TODO: Add stuff below
+// TODO: Make variables configurable
+const backendServiceId = ''; // run `gcloud compute backend-services describe SERVICE_NAME --project=PROJECT_ID --global` (id)
+const projectNumber = ''; // run `gcloud projects describe PROJECT_ID` (projectNumber (INT))
+const expectedAudience = `/projects/${projectNumber}/global/backendServices/${backendServiceId}`;
 
 module.exports = async (ctx, next) => {
   let role = await strapi
@@ -29,11 +36,11 @@ module.exports = async (ctx, next) => {
       ['https://cloud.google.com/iap']
     );
     const payload = ticket.getPayload();
-    if (!ticket || !payload) {
+    if (!ticket || !payload) {
       return handleErrors(ctx, undefined, 'forbidden');
     }
 
-    const email = payload.email;
+    const { email } = payload;
 
     ctx.state.user = await strapi.plugins[
       'users-permissions'
@@ -70,7 +77,7 @@ module.exports = async (ctx, next) => {
     role = ctx.state.user.role;
   }
 
-  const route = ctx.request.route;
+  const { route } = ctx.request;
   const permission = await strapi
     .query('permission', 'users-permissions')
     .findOne(

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "prettier": "^2.3.1"
   },
   "dependencies": {
+    "google-auth-library": "^7.1.2",
     "knex": "0.21.18",
     "pg": "^8.6.0",
     "sqlite3": "5.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1934,6 +1934,13 @@ abbrev@1:
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
   integrity sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==
 
+abort-controller@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/abort-controller/-/abort-controller-3.0.0.tgz#eaf54d53b62bae4138e809ca225c8439a6efb392"
+  integrity sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==
+  dependencies:
+    event-target-shim "^5.0.0"
+
 accepts@^1.3.5, accepts@~1.3.4, accepts@~1.3.5, accepts@~1.3.7:
   version "1.3.7"
   resolved "https://registry.yarnpkg.com/accepts/-/accepts-1.3.7.tgz#531bc726517a3b2b41f850021c6cc15eaab507cd"
@@ -2424,6 +2431,11 @@ arrify@^1.0.1:
   resolved "https://registry.yarnpkg.com/arrify/-/arrify-1.0.1.tgz#898508da2226f380df904728456849c1501a4b0d"
   integrity sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=
 
+arrify@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/arrify/-/arrify-2.0.1.tgz#c9655e9331e0abcd588d2a7cad7e9956f66701fa"
+  integrity sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==
+
 asap@~2.0.3:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/asap/-/asap-2.0.6.tgz#e50347611d7e690943208bbdafebcbc2fb866d46"
@@ -2609,7 +2621,7 @@ balanced-match@^1.0.0:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
   integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
 
-base64-js@^1.0.2, base64-js@^1.3.1:
+base64-js@^1.0.2, base64-js@^1.3.0, base64-js@^1.3.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
   integrity sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==
@@ -2658,6 +2670,11 @@ big.js@^5.2.2:
   version "5.2.2"
   resolved "https://registry.yarnpkg.com/big.js/-/big.js-5.2.2.tgz#65f0af382f578bcdc742bd9c281e9cb2d7768328"
   integrity sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==
+
+bignumber.js@^9.0.0:
+  version "9.0.1"
+  resolved "https://registry.yarnpkg.com/bignumber.js/-/bignumber.js-9.0.1.tgz#8d7ba124c882bfd8e43260c67475518d0689e4e5"
+  integrity sha512-IdZR9mh6ahOBv/hYGiXyVuyCetmGJhtYkqLBpTStdhEGjegpPlUawydyaF3pbIOFynJTpllEs+NP+CS9jKFLjA==
 
 binary-extensions@^1.0.0:
   version "1.13.1"
@@ -4288,7 +4305,7 @@ ecc-jsbn@~0.1.1:
     jsbn "~0.1.0"
     safer-buffer "^2.1.0"
 
-ecdsa-sig-formatter@1.0.11:
+ecdsa-sig-formatter@1.0.11, ecdsa-sig-formatter@^1.0.11:
   version "1.0.11"
   resolved "https://registry.yarnpkg.com/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz#ae0f0fa2d85045ef14a817daa3ce9acd0489e5bf"
   integrity sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==
@@ -4695,6 +4712,11 @@ etag@~1.8.1:
   resolved "https://registry.yarnpkg.com/etag/-/etag-1.8.1.tgz#41ae2eeb65efa62268aebfea83ac7d79299b0887"
   integrity sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=
 
+event-target-shim@^5.0.0:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/event-target-shim/-/event-target-shim-5.0.1.tgz#5d4d3ebdf9583d63a5333ce2deb7480ab2b05789"
+  integrity sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==
+
 eventemitter3@^3.1.0:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-3.1.2.tgz#2d3d48f9c346698fce83a85d7d664e98535df6e7"
@@ -4814,7 +4836,7 @@ extend-shallow@^3.0.0, extend-shallow@^3.0.2:
     assign-symbols "^1.0.0"
     is-extendable "^1.0.1"
 
-extend@^3.0.0, extend@~3.0.2:
+extend@^3.0.0, extend@^3.0.2, extend@~3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.2.tgz#f8b1136b4071fbd8eb140aff858b1019ec2915fa"
   integrity sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==
@@ -4881,6 +4903,11 @@ fast-safe-stringify@^1.0.8, fast-safe-stringify@^1.2.3:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/fast-safe-stringify/-/fast-safe-stringify-1.2.3.tgz#9fe22c37fb2f7f86f06b8f004377dbf8f1ee7bc1"
   integrity sha512-QJYT/i0QYoiZBQ71ivxdyTqkwKkQ0oxACXHYxH2zYHJEgzi2LsbjgvtzTbLi1SZcF190Db2YP7I7eTsU2egOlw==
+
+fast-text-encoding@^1.0.0:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/fast-text-encoding/-/fast-text-encoding-1.0.3.tgz#ec02ac8e01ab8a319af182dae2681213cfe9ce53"
+  integrity sha512-dtm4QZH9nZtcDt8qJiOH9fcQd1NAgi+K1O2DbE6GG1PPCK/BWfOH3idCTRQ4ImXRUOyopDEgDEnVEE7Y/2Wrig==
 
 fastparse@^1.1.1:
   version "1.1.2"
@@ -5314,6 +5341,25 @@ gauge@~2.7.3:
     strip-ansi "^3.0.1"
     wide-align "^1.1.0"
 
+gaxios@^4.0.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/gaxios/-/gaxios-4.3.0.tgz#ad4814d89061f85b97ef52aed888c5dbec32f774"
+  integrity sha512-pHplNbslpwCLMyII/lHPWFQbJWOX0B3R1hwBEOvzYi1GmdKZruuEHK4N9V6f7tf1EaPYyF80mui1+344p6SmLg==
+  dependencies:
+    abort-controller "^3.0.0"
+    extend "^3.0.2"
+    https-proxy-agent "^5.0.0"
+    is-stream "^2.0.0"
+    node-fetch "^2.3.0"
+
+gcp-metadata@^4.2.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/gcp-metadata/-/gcp-metadata-4.3.0.tgz#0423d06becdbfb9cbb8762eaacf14d5324997900"
+  integrity sha512-L9XQUpvKJCM76YRSmcxrR4mFPzPGsgZUH+GgHMxAET8qc6+BhRJq63RLhWakgEO2KKVgeSDVfyiNjkGSADwNTA==
+  dependencies:
+    gaxios "^4.0.0"
+    json-bigint "^1.0.0"
+
 gensync@^1.0.0-beta.2:
   version "1.0.0-beta.2"
   resolved "https://registry.yarnpkg.com/gensync/-/gensync-1.0.0-beta.2.tgz#32a6ee76c3d7f52d46b2b1ae5d93fea8580a25e0"
@@ -5478,6 +5524,28 @@ globby@^6.1.0:
     pify "^2.0.0"
     pinkie-promise "^2.0.0"
 
+google-auth-library@^7.1.2:
+  version "7.1.2"
+  resolved "https://registry.yarnpkg.com/google-auth-library/-/google-auth-library-7.1.2.tgz#29fc0fe8b6d5a59b93b7cb561b1a28bcc93360b7"
+  integrity sha512-FMipHgfe2u1LzWsf2n9zEB9KsJ8M3n8OYTHbHtlkzPCyo7IknXQR5X99nfvwUHGuX+iEpihUZxDuPm7+qBYeXg==
+  dependencies:
+    arrify "^2.0.0"
+    base64-js "^1.3.0"
+    ecdsa-sig-formatter "^1.0.11"
+    fast-text-encoding "^1.0.0"
+    gaxios "^4.0.0"
+    gcp-metadata "^4.2.0"
+    gtoken "^5.0.4"
+    jws "^4.0.0"
+    lru-cache "^6.0.0"
+
+google-p12-pem@^3.0.3:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/google-p12-pem/-/google-p12-pem-3.1.0.tgz#a1421b432fcc926812e3835289807170768a9885"
+  integrity sha512-JUtEHXL4DY/N+xhlm7TC3qL797RPAtk0ZGXNs3/gWyiDHYoA/8Rjes0pztkda+sZv4ej1EoO2KhWgW5V9KTrSQ==
+  dependencies:
+    node-forge "^0.10.0"
+
 got@^9.6.0:
   version "9.6.0"
   resolved "https://registry.yarnpkg.com/got/-/got-9.6.0.tgz#edf45e7d67f99545705de1f7bbeeeb121765ed85"
@@ -5606,6 +5674,15 @@ graphql@15.5.0:
   version "15.5.0"
   resolved "https://registry.yarnpkg.com/graphql/-/graphql-15.5.0.tgz#39d19494dbe69d1ea719915b578bf920344a69d5"
   integrity sha512-OmaM7y0kaK31NKG31q4YbD2beNYa6jBBKtMFT6gLYJljHLJr42IqJ8KX08u3Li/0ifzTU5HjmoOOrwa5BRLeDA==
+
+gtoken@^5.0.4:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/gtoken/-/gtoken-5.3.0.tgz#6536eb2880d9829f0b9d78f756795d4d9064b217"
+  integrity sha512-mCcISYiaRZrJpfqOs0QWa6lfEM/C1V9ASkzFmuz43XBb5s1Vynh+CZy1ECeeJXVGx2PRByjYzb4Y4/zr1byr0w==
+  dependencies:
+    gaxios "^4.0.0"
+    google-p12-pem "^3.0.3"
+    jws "^4.0.0"
 
 gud@^1.0.0:
   version "1.0.0"
@@ -6463,6 +6540,11 @@ is-stream@^1.1.0:
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
   integrity sha1-EtSj3U5o4Lec6428hBc66A2RykQ=
 
+is-stream@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-2.0.0.tgz#bde9c32680d6fae04129d6ac9d921ce7815f78e3"
+  integrity sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==
+
 is-string@^1.0.5, is-string@^1.0.6:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/is-string/-/is-string-1.0.6.tgz#3fe5d5992fb0d93404f32584d4b0179a71b54a5f"
@@ -6612,6 +6694,13 @@ jsesc@~0.5.0:
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-0.5.0.tgz#e7dee66e35d6fc16f710fe91d5cf69f70f08911d"
   integrity sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=
+
+json-bigint@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/json-bigint/-/json-bigint-1.0.0.tgz#ae547823ac0cad8398667f8cd9ef4730f5b01ff1"
+  integrity sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==
+  dependencies:
+    bignumber.js "^9.0.0"
 
 json-buffer@3.0.0:
   version "3.0.0"
@@ -7881,7 +7970,7 @@ node-addon-api@^3.1.0:
   resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-3.2.1.tgz#81325e0a2117789c0128dab65e7e38f07ceba161"
   integrity sha512-mmcei9JghVNDYydghQmeDX8KoAm0FAiYyIcUt/N4nhyAipB17pllZQDOJD2fotxABnt4Mdz+dKTO7eftLg4d0A==
 
-node-fetch@2.6.1, node-fetch@^2.1.2, node-fetch@^2.2.0, node-fetch@^2.6.1:
+node-fetch@2.6.1, node-fetch@^2.1.2, node-fetch@^2.2.0, node-fetch@^2.3.0, node-fetch@^2.6.1:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
   integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==


### PR DESCRIPTION
This pull request adds two new environment variables:

- `BACKEND_SERVICE_ID` which can be retrieved by running `gcloud compute backend-services describe SERVICE_NAME --project=PROJECT_ID --global`. Only possible after `Backend` resource is applied.
- `PROJECT_NUMBER` which can be retrieved `gcloud projects describe PROJECT_ID`. It's not `fdk-something-prod`, it's more likely something like this: `884845229805`.