### PR TITLE
feat: support slugs for fancy articles

### DIFF
--- a/src/api/fancy-article/content-types/fancy-article/schema.json
+++ b/src/api/fancy-article/content-types/fancy-article/schema.json
@@ -43,6 +43,14 @@
         }
       },
       "type": "text"
+    },
+    "slug": {
+      "type": "string",
+      "pluginOptions": {
+        "i18n": {
+          "localized": true
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
Fancy artikler i Strapi i prod må oppdateres med korrekt slug (samme som brukt i staging).
Denne PR-en gjør at vi ikke trenger å hardkode artikkel-iden i fdk-portal, men kan i stedet for referere til sluggen (f.eks. `/about`)