### PR TITLE
fix: bump shell-quote to 1.8.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "wrap-ansi": "7.0.0"
   },
   "resolutions": {
+    "shell-quote": "^1.8.4",
     "ajv": "^8.18.0",
     "bn.js": "^5.2.3",
     "axios": "^1.15.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10462,10 +10462,10 @@ shebang-regex@^3.0.0:
   resolved "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz"
   integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
 
-shell-quote@^1.8.1:
-  version "1.8.3"
-  resolved "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz"
-  integrity sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==
+shell-quote@^1.8.1, shell-quote@^1.8.4:
+  version "1.8.4"
+  resolved "https://registry.yarnpkg.com/shell-quote/-/shell-quote-1.8.4.tgz#2edd9a4dcefc96649e2e2cb12f637b1f1d92a190"
+  integrity sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==
 
 side-channel-list@^1.0.0:
   version "1.0.1"


### PR DESCRIPTION
# Summary

- Adds shell-quote ^1.8.4 resolution to force the patched transitive version
- Resolves critical Dependabot alert #160 (GHSA shell-quote command injection)