### PR TITLE
fix: bump @koa/router to 15

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "devDependencies": {
     "@babel/runtime": "^7.28.3",
-    "@koa/router": "^14.0.0",
+    "@koa/router": "^15.0.0",
     "@types/node": "^22.0.0",
     "@types/react": "^18.0.0",
     "@typescript-eslint/eslint-plugin": "^7.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1253,15 +1253,15 @@
     methods "^1.1.2"
     path-to-regexp "^6.3.0"
 
-"@koa/router@^14.0.0":
-  version "14.0.0"
-  resolved "https://registry.npmjs.org/@koa/router/-/router-14.0.0.tgz"
-  integrity sha512-LBSu5K0qAaaQcXX/0WIB9PGDevyCxxpnc1uq13vV/CgObaVxuis5hKl3Eboq/8gcb6ebnkAStW9NB/Em2eYyFA==
+"@koa/router@^15.0.0":
+  version "15.7.0"
+  resolved "https://registry.yarnpkg.com/@koa/router/-/router-15.7.0.tgz#e3448a6f8c541ddcfe4bbce49debac94f51fe20f"
+  integrity sha512-WaAlk4TOl/O0rhTpOR0l052gz03syPMmI6Pe2gd7v3ubjfv5UcSGcnb0Y/J5NNC/ln+5FiUqPJTc/a15I+XqAA==
   dependencies:
-    debug "^4.4.1"
-    http-errors "^2.0.0"
+    debug "^4.4.3"
+    http-errors "^2.0.1"
     koa-compose "^4.1.0"
-    path-to-regexp "^8.2.0"
+    path-to-regexp "^8.4.2"
 
 "@lezer/common@^1.0.0", "@lezer/common@^1.1.0", "@lezer/common@^1.2.0", "@lezer/common@^1.3.0":
   version "1.4.0"
@@ -5070,7 +5070,7 @@ debug@4.3.4:
   dependencies:
     ms "2.1.2"
 
-debug@4.4.3, debug@^4, debug@^4.0.0, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@^4.3.2, debug@^4.3.3, debug@^4.3.4, debug@^4.4.1, debug@^4.4.3:
+debug@4.4.3, debug@^4, debug@^4.0.0, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@^4.3.2, debug@^4.3.3, debug@^4.3.4, debug@^4.4.3:
   version "4.4.3"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.4.3.tgz#c6ae432d9bd9662582fce08709b038c58e9e3d6a"
   integrity sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==
@@ -6887,7 +6887,7 @@ http-errors@^1.6.3, http-errors@^1.7.3, http-errors@^1.8.1, http-errors@~1.8.0:
     statuses ">= 1.5.0 < 2"
     toidentifier "1.0.1"
 
-http-errors@^2.0.0, http-errors@~2.0.1:
+http-errors@^2.0.0, http-errors@^2.0.1, http-errors@~2.0.1:
   version "2.0.1"
   resolved "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz"
   integrity sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==
@@ -9312,7 +9312,7 @@ path-scurry@^1.11.1:
     lru-cache "^10.2.0"
     minipass "^5.0.0 || ^6.0.2 || ^7.0.0"
 
-path-to-regexp@^6.3.0, path-to-regexp@^8.2.0:
+path-to-regexp@^6.3.0, path-to-regexp@^8.4.2:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-6.3.0.tgz#2b6a26a337737a8e1416f9272ed0766b1c0389f4"
   integrity sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==


### PR DESCRIPTION
# Summary

- Bump direct @koa/router ^14.0.0 → ^15.0.0 (resolves 15.7.0) to fix security alert (#178/#179, Moderate)
- Strapi's internal @koa/router@12.0.2 is left as-is (pinned by @strapi/core; upstream-controlled)
- Verified: strapi build succeeds